### PR TITLE
DB制約・カラム型・ER図の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,17 @@ https://www.e-stat.go.jp/stat-search/files?page=1&layout=datalist&toukei=0045027
 3.SNS共有機能
 4.オートコンプリート機能
 5.タグ機能
-6.LINEプッシュ通知
+6.LINE認証・bot機能
 7.Google認証
-8.コメント作成 
-9.コメント編集 
+8.コメント作成
+9.コメント編集
 10.コメント削除
 
 ## ■ 機能の実装方針予定
 
 - 検索機能：gem ransack
 - オートコンプリート機能：Stimulus Autocomplete（Rails7 ）
-- LINEプッシュ通知： LINE Messaging API、LINE Messaging API SDK for Ruby
+- LINE認証・bot機能： LINE Messaging API、LINE Messaging API SDK for Ruby
 
 # 使用技術（予定）
 
@@ -186,4 +186,4 @@ https://www.figma.com/design/nyig3NgC0ol8JWr83RJxCV/GrowFitty?node-id=0-1&t=FM9r
 
 dbdiagram.io：https://dbdiagram.io/d/680d95001ca52373f57f695f
 
-[![Image from Gyazo](https://i.gyazo.com/d711904af86e5e5add4d1501384d4524.png)](https://gyazo.com/d711904af86e5e5add4d1501384d4524)
+[![Image from Gyazo](https://i.gyazo.com/72b2469fa41827d19d97725d58d80b0a.png)](https://gyazo.com/72b2469fa41827d19d97725d58d80b0a)

--- a/db/migrate/20260208101212_fix_null_constraints_and_column_types.rb
+++ b/db/migrate/20260208101212_fix_null_constraints_and_column_types.rb
@@ -1,0 +1,17 @@
+class FixNullConstraintsAndColumnTypes < ActiveRecord::Migration[7.2]
+  def change
+    # NOT NULL制約の追加
+    change_column_null :bookmarks, :user_id, false
+    change_column_null :bookmarks, :post_id, false
+    change_column_null :comments, :user_id, false
+    change_column_null :comments, :post_id, false
+    change_column_null :comments, :body, false
+    change_column_null :posts, :user_id, false
+    change_column_null :post_tags, :post_id, false
+    change_column_null :post_tags, :tag_id, false
+
+    # カラム型の変更（datetime → date）
+    change_column :children, :birthday, :date, null: false
+    change_column :measurements, :measured_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_09_190027) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_08_101212) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bookmarks", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "post_id"
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_bookmarks_on_post_id"
@@ -28,16 +28,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_09_190027) do
     t.bigint "user_id", null: false
     t.string "name", null: false
     t.string "gender", null: false
-    t.datetime "birthday", null: false
+    t.date "birthday", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_children_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "post_id"
-    t.text "body"
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
@@ -72,7 +72,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_09_190027) do
 
   create_table "measurements", force: :cascade do |t|
     t.bigint "child_id", null: false
-    t.datetime "measured_on"
+    t.date "measured_on"
     t.string "measurement_type", null: false
     t.float "value"
     t.float "percentile"
@@ -82,8 +82,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_09_190027) do
   end
 
   create_table "post_tags", force: :cascade do |t|
-    t.bigint "post_id"
-    t.bigint "tag_id"
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
@@ -94,7 +94,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_09_190027) do
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "post_image"


### PR DESCRIPTION
DB制約・カラム型の修正・ER図の修正に伴い以下を対応しました。

- [ ] 外部キーカラムにNOT NULL制約を追加（bookmarks, comments, posts, post_tags）

- [ ] comments.bodyにNOT NULL制約を追加

- [ ] children.birthdayの型をdatetime→dateに変更

- [ ] measurements.measured_onの型をdatetime→dateに変更

- [ ] README修正